### PR TITLE
Restore native Reflex marker forwarding

### DIFF
--- a/libs/vkd3d/device_vkd3d_ext.c
+++ b/libs/vkd3d/device_vkd3d_ext.c
@@ -1275,7 +1275,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencySleepMode(d3
 
 static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencyMarker(d3d_low_latency_device_iface *iface, UINT64 frameID, UINT32 markerType)
 {
-    // struct dxgi_vk_swap_chain *low_latency_swapchain;
+    struct dxgi_vk_swap_chain *low_latency_swapchain;
     VkLatencyMarkerNV vk_marker;
     struct d3d12_device *device;
     uint64_t internal_frame_id;
@@ -1322,16 +1322,19 @@ static HRESULT STDMETHODCALLTYPE d3d12_low_latency_device_SetLatencyMarker(d3d_l
             break;
     }
 
-    // spinlock_acquire(&device->low_latency_swapchain_spinlock);
-    // if ((low_latency_swapchain = device->swapchain_info.low_latency_swapchain))
-    //     dxgi_vk_swap_chain_incref(low_latency_swapchain);
-    // spinlock_release(&device->low_latency_swapchain_spinlock);
-    //
-    // if (low_latency_swapchain)
-    // {
-    //     dxgi_vk_swap_chain_set_latency_marker(low_latency_swapchain, internal_frame_id, vk_marker, true);
-    //     dxgi_vk_swap_chain_decref(low_latency_swapchain);
-    // }
+    spinlock_acquire(&device->low_latency_swapchain_spinlock);
+    if ((low_latency_swapchain = device->swapchain_info.low_latency_swapchain))
+        dxgi_vk_swap_chain_acquire_latency_marker_reference(low_latency_swapchain);
+    spinlock_release(&device->low_latency_swapchain_spinlock);
+
+    if (low_latency_swapchain)
+    {
+#ifdef VKD3D_ENABLE_TEST_HOOKS
+        dxgi_vk_swap_chain_test_marker_invoke_callback();
+#endif
+        dxgi_vk_swap_chain_set_latency_marker(low_latency_swapchain, frameID, vk_marker, true);
+        dxgi_vk_swap_chain_release_latency_marker_reference(low_latency_swapchain);
+    }
 
     return S_OK;
 }

--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -125,7 +125,8 @@ endif
 
 vkd3d_lib = static_library('vkd3d-proton', vkd3d_src, glsl_generator.process(vkd3d_shaders), vkd3d_build, vkd3d_version,
   dependencies        : [ vkd3d_common_dep, vkd3d_shader_dep ] + vkd3d_extra_libs,
-  include_directories : vkd3d_private_includes)
+  include_directories : vkd3d_private_includes,
+  c_args              : enable_tests ? ['-DVKD3D_ENABLE_TEST_HOOKS'] : [])
 
 vkd3d_dep = declare_dependency(
   link_with           : [ vkd3d_lib, vkd3d_common_lib ],

--- a/libs/vkd3d/swapchain.c
+++ b/libs/vkd3d/swapchain.c
@@ -4080,35 +4080,25 @@ void dxgi_vk_swap_chain_set_latency_sleep_mode(struct dxgi_vk_swap_chain *chain,
 void dxgi_vk_swap_chain_set_latency_marker(struct dxgi_vk_swap_chain *chain,
         uint64_t frameID, VkLatencyMarkerNV marker, bool from_app)
 {
-    // const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
-    // VkSetLatencyMarkerInfoNV latency_marker_info;
-    //
-    // if (from_app && (marker == VK_LATENCY_MARKER_OUT_OF_BAND_PRESENT_START_NV
-    //                  || marker == VK_LATENCY_MARKER_OUT_OF_BAND_PRESENT_END_NV))
-    // {
-    //     /* Record the frame ID for OUT_OF_BAND_PRESENT markers. We'll send
-    //      * these markers later on our background present thread. */
-    //     vkd3d_atomic_uint64_store_explicit(&chain->queue->device->frame_markers.out_of_band_present,
-    //             marker == VK_LATENCY_MARKER_OUT_OF_BAND_PRESENT_START_NV ? frameID : 0,
-    //             vkd3d_memory_order_release);
-    //     return;
-    // }
-    //
-    // memset(&latency_marker_info, 0, sizeof(latency_marker_info));
-    // latency_marker_info.sType = VK_STRUCTURE_TYPE_SET_LATENCY_MARKER_INFO_NV;
-    // latency_marker_info.pNext = NULL;
-    // latency_marker_info.presentID = frameID;
-    // latency_marker_info.marker = marker;
-    //
-    // if (chain->debug_latency && marker == VK_LATENCY_MARKER_PRESENT_START_NV)
-    //     INFO("Setting present frame marker %"PRIu64".\n", frameID);
-    //
-    // pthread_mutex_lock(&chain->present.low_latency_swapchain_lock);
-    //
-    // if (chain->present.vk_swapchain)
-    //     VK_CALL(vkSetLatencyMarkerNV(chain->queue->device->vk_device, chain->present.vk_swapchain, &latency_marker_info));
-    //
-    // pthread_mutex_unlock(&chain->present.low_latency_swapchain_lock);
+    const struct vkd3d_vk_device_procs *vk_procs = &chain->queue->device->vk_procs;
+    VkSetLatencyMarkerInfoNV latency_marker_info;
+
+    if (!from_app)
+        return;
+
+    memset(&latency_marker_info, 0, sizeof(latency_marker_info));
+    latency_marker_info.sType = VK_STRUCTURE_TYPE_SET_LATENCY_MARKER_INFO_NV;
+    latency_marker_info.presentID = frameID;
+    latency_marker_info.marker = marker;
+
+    pthread_mutex_lock(&chain->present.low_latency_swapchain_lock);
+
+    if (chain->queue->device->vk_info.NV_low_latency2 &&
+            chain->present.vk_swapchain && vk_procs->vkSetLatencyMarkerNV)
+        VK_CALL(vkSetLatencyMarkerNV(chain->queue->device->vk_device,
+                chain->present.vk_swapchain, &latency_marker_info));
+
+    pthread_mutex_unlock(&chain->present.low_latency_swapchain_lock);
 }
 
 void dxgi_vk_swap_chain_get_latency_info(struct dxgi_vk_swap_chain *chain, D3D12_LATENCY_RESULTS *latency_results)
@@ -4190,6 +4180,14 @@ ULONG dxgi_vk_swap_chain_incref(struct dxgi_vk_swap_chain *chain)
     return refcount;
 }
 
+void dxgi_vk_swap_chain_acquire_latency_marker_reference(struct dxgi_vk_swap_chain *chain)
+{
+    /* Swapchain cleanup accesses the queue, so retain both while the selected
+     * swapchain lock is dropped for the Vulkan call. */
+    dxgi_vk_swap_chain_incref(chain);
+    ID3D12CommandQueue_AddRef(&chain->queue->ID3D12CommandQueue_iface);
+}
+
 ULONG dxgi_vk_swap_chain_decref(struct dxgi_vk_swap_chain *chain)
 {
     unsigned int refcount = InterlockedDecrement(&chain->internal_refcount);
@@ -4205,6 +4203,83 @@ ULONG dxgi_vk_swap_chain_decref(struct dxgi_vk_swap_chain *chain)
 
     return refcount;
 }
+
+void dxgi_vk_swap_chain_release_latency_marker_reference(struct dxgi_vk_swap_chain *chain)
+{
+    struct d3d12_command_queue *queue = chain->queue;
+
+    /* The queue reference must outlive a possible final chain release. */
+    dxgi_vk_swap_chain_decref(chain);
+    ID3D12CommandQueue_Release(&queue->ID3D12CommandQueue_iface);
+}
+
+#ifdef VKD3D_ENABLE_TEST_HOOKS
+static dxgi_vk_swap_chain_marker_test_callback marker_test_callback;
+static void *marker_test_userdata;
+
+bool dxgi_vk_swap_chain_test_marker_init(struct d3d12_command_queue *queue,
+        IDXGIVkSwapChain **out)
+{
+    struct dxgi_vk_swap_chain *chain;
+
+    if (!(chain = vkd3d_calloc(1, sizeof(*chain))))
+        return false;
+
+    chain->IDXGIVkSwapChain_iface.lpVtbl = &dxgi_vk_swap_chain_vtbl;
+    chain->refcount = 1;
+    chain->internal_refcount = 1;
+    chain->queue = queue;
+    chain->desc.BufferCount = 2;
+    pthread_mutex_init(&chain->present.low_latency_swapchain_lock, NULL);
+    pthread_mutex_init(&chain->present.low_latency_state_update_lock, NULL);
+    pthread_mutex_init(&chain->frame_rate_limit.lock, NULL);
+    pthread_mutex_init(&chain->properties.lock, NULL);
+    pthread_mutex_init(&chain->timing.lock, NULL);
+
+    if (FAILED(dxgi_vk_swap_chain_init_waiter_thread(chain)))
+        goto fail;
+
+    pacer_register_swapchain(queue->device->pacer_device, chain, queue, chain->desc, NULL);
+    ID3D12CommandQueue_AddRef(&queue->ID3D12CommandQueue_iface);
+    *out = (IDXGIVkSwapChain *)&chain->IDXGIVkSwapChain_iface;
+    return true;
+
+fail:
+    pthread_mutex_destroy(&chain->timing.lock);
+    pthread_mutex_destroy(&chain->properties.lock);
+    pthread_mutex_destroy(&chain->frame_rate_limit.lock);
+    pthread_mutex_destroy(&chain->present.low_latency_state_update_lock);
+    pthread_mutex_destroy(&chain->present.low_latency_swapchain_lock);
+    vkd3d_free(chain);
+    return false;
+}
+
+void dxgi_vk_swap_chain_test_marker_register(struct d3d12_device *device,
+        IDXGIVkSwapChain *iface)
+{
+    d3d12_device_register_swapchain(device,
+            impl_from_IDXGIVkSwapChain((IDXGIVkSwapChain2 *)iface));
+}
+
+void dxgi_vk_swap_chain_test_marker_set_swapchain(IDXGIVkSwapChain *iface,
+        VkSwapchainKHR vk_swapchain)
+{
+    impl_from_IDXGIVkSwapChain((IDXGIVkSwapChain2 *)iface)->present.vk_swapchain = vk_swapchain;
+}
+
+void dxgi_vk_swap_chain_test_marker_set_callback(dxgi_vk_swap_chain_marker_test_callback callback,
+        void *userdata)
+{
+    marker_test_callback = callback;
+    marker_test_userdata = userdata;
+}
+
+void dxgi_vk_swap_chain_test_marker_invoke_callback(void)
+{
+    if (marker_test_callback)
+        marker_test_callback(marker_test_userdata);
+}
+#endif
 
 HRESULT dxgi_vk_swap_chain_factory_init(struct d3d12_command_queue *queue, struct dxgi_vk_swap_chain_factory *chain)
 {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -3813,6 +3813,21 @@ void dxgi_vk_swap_chain_get_latency_info(struct dxgi_vk_swap_chain *chain,
 
 ULONG dxgi_vk_swap_chain_incref(struct dxgi_vk_swap_chain *chain);
 ULONG dxgi_vk_swap_chain_decref(struct dxgi_vk_swap_chain *chain);
+void dxgi_vk_swap_chain_acquire_latency_marker_reference(struct dxgi_vk_swap_chain *chain);
+void dxgi_vk_swap_chain_release_latency_marker_reference(struct dxgi_vk_swap_chain *chain);
+
+#ifdef VKD3D_ENABLE_TEST_HOOKS
+typedef void (*dxgi_vk_swap_chain_marker_test_callback)(void *userdata);
+bool dxgi_vk_swap_chain_test_marker_init(struct d3d12_command_queue *queue,
+        IDXGIVkSwapChain **out);
+void dxgi_vk_swap_chain_test_marker_register(struct d3d12_device *device,
+        IDXGIVkSwapChain *iface);
+void dxgi_vk_swap_chain_test_marker_set_swapchain(IDXGIVkSwapChain *iface,
+        VkSwapchainKHR vk_swapchain);
+void dxgi_vk_swap_chain_test_marker_set_callback(dxgi_vk_swap_chain_marker_test_callback callback,
+        void *userdata);
+void dxgi_vk_swap_chain_test_marker_invoke_callback(void);
+#endif
 
 HRESULT dxgi_vk_swap_chain_factory_init(struct d3d12_command_queue *queue, struct dxgi_vk_swap_chain_factory *chain);
 

--- a/tests/marker_forwarding.c
+++ b/tests/marker_forwarding.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2026 The vkd3d-proton authors
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#define COBJMACROS
+#include <vkd3d.h>
+#define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
+#include "vkd3d_private.h"
+
+#ifdef _WIN32
+static HMODULE load_vulkan_loader(PFN_vkGetInstanceProcAddr *vkGetInstanceProcAddr)
+{
+    HMODULE module;
+
+    if (!(module = LoadLibraryA("vulkan-1.dll")))
+    {
+        fprintf(stderr, "Failed to load vulkan-1.dll, error %lu.\n", GetLastError());
+        return NULL;
+    }
+
+    if (!(*vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)(void *)GetProcAddress(module,
+            "vkGetInstanceProcAddr")))
+    {
+        fprintf(stderr, "Failed to get vkGetInstanceProcAddr from vulkan-1.dll, error %lu.\n", GetLastError());
+        FreeLibrary(module);
+        return NULL;
+    }
+
+    return module;
+}
+#endif
+
+struct marker_test
+{
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    bool acquired;
+    bool resume;
+    unsigned int calls;
+    uint64_t frame_id;
+    VkLatencyMarkerNV marker;
+    IDXGIVkSwapChain *chain;
+    struct d3d12_device *device;
+};
+
+static struct marker_test *marker_test;
+
+bool vkd3d_debug_control_is_test_suite(void)
+{
+    return true;
+}
+
+bool vkd3d_debug_control_explode_on_vvl_error(void)
+{
+    return false;
+}
+
+bool vkd3d_debug_control_has_out_of_spec_test_behavior(unsigned int behavior)
+{
+    (void)behavior;
+    return false;
+}
+
+unsigned int vkd3d_debug_control_get_behavior_flags(void)
+{
+    return 0;
+}
+
+bool vkd3d_debug_control_mute_message_id(const char *vuid)
+{
+    (void)vuid;
+    return false;
+}
+
+static void marker_test_pause(void *userdata)
+{
+    struct marker_test *test = userdata;
+
+    pthread_mutex_lock(&test->mutex);
+    /* The marker path has retained both objects and released the selection lock. */
+    test->acquired = true;
+    pthread_cond_broadcast(&test->cond);
+    while (!test->resume)
+        pthread_cond_wait(&test->cond, &test->mutex);
+    pthread_mutex_unlock(&test->mutex);
+}
+
+static VKAPI_ATTR void VKAPI_CALL marker_test_set_latency_marker(VkDevice device,
+        VkSwapchainKHR swapchain, const VkSetLatencyMarkerInfoNV *info)
+{
+    struct marker_test *test = marker_test;
+
+    (void)device;
+    (void)swapchain;
+    pthread_mutex_lock(&test->mutex);
+    ++test->calls;
+    test->frame_id = info->presentID;
+    test->marker = info->marker;
+    dxgi_vk_swap_chain_test_marker_set_swapchain(test->chain, VK_NULL_HANDLE);
+    pthread_mutex_unlock(&test->mutex);
+}
+
+static void *marker_test_thread(void *userdata)
+{
+    struct marker_test *test = userdata;
+
+    ID3DLowLatencyDevice_SetLatencyMarker(&test->device->ID3DLowLatencyDevice_iface,
+            UINT64_C(0x123456789abcdef0), VK_LATENCY_MARKER_RENDERSUBMIT_START_NV);
+    return NULL;
+}
+
+static bool marker_forwarding_test(void)
+{
+    static const char * const device_extensions[] = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+    static const char * const instance_extensions[] = {VK_KHR_SURFACE_EXTENSION_NAME};
+    struct vkd3d_instance_create_info instance_info =
+    {
+        .instance_extensions = instance_extensions,
+        .instance_extension_count = ARRAY_SIZE(instance_extensions),
+    };
+    const struct vkd3d_device_create_info device_info =
+    {
+        .minimum_feature_level = D3D_FEATURE_LEVEL_11_0,
+        .instance_create_info = &instance_info,
+        .device_extensions = device_extensions,
+        .device_extension_count = ARRAY_SIZE(device_extensions),
+    };
+    struct marker_test test = {0};
+    struct d3d12_command_queue *queue = NULL;
+    ID3D12CommandQueue *queue_iface = NULL;
+    ID3D12Device *device = NULL;
+    D3D12_COMMAND_QUEUE_DESC desc = {0};
+    PFN_vkSetLatencyMarkerNV saved_marker = NULL;
+    pthread_t thread;
+    HRESULT hr;
+    bool result = false;
+    bool mutex_initialized = false;
+    bool cond_initialized = false;
+    bool marker_test_registered = false;
+    bool marker_callback_set = false;
+    bool thread_created = false;
+#ifdef _WIN32
+    HMODULE vulkan_module = NULL;
+
+    if (!(vulkan_module = load_vulkan_loader(&instance_info.pfn_vkGetInstanceProcAddr)))
+        return false;
+#endif
+
+    if (FAILED(vkd3d_create_device(&device_info, &IID_ID3D12Device, (void **)&device)))
+        goto cleanup;
+    if (FAILED(ID3D12Device_CreateCommandQueue(device, &desc,
+            &IID_ID3D12CommandQueue, (void **)&queue_iface)))
+        goto cleanup;
+
+    test.device = impl_from_ID3D12Device((d3d12_device_iface *)device);
+    queue = CONTAINING_RECORD(queue_iface, struct d3d12_command_queue, ID3D12CommandQueue_iface);
+    if (!dxgi_vk_swap_chain_test_marker_init(queue, &test.chain))
+        goto cleanup;
+
+    if (pthread_mutex_init(&test.mutex, NULL))
+        goto cleanup;
+    mutex_initialized = true;
+    if (pthread_cond_init(&test.cond, NULL))
+        goto cleanup;
+    cond_initialized = true;
+    marker_test = &test;
+    marker_test_registered = true;
+    saved_marker = test.device->vk_procs.vkSetLatencyMarkerNV;
+    dxgi_vk_swap_chain_test_marker_set_swapchain(test.chain, (VkSwapchainKHR)(uintptr_t)1);
+    dxgi_vk_swap_chain_test_marker_register(test.device, test.chain);
+
+    test.device->vk_info.NV_low_latency2 = false;
+    hr = ID3DLowLatencyDevice_SetLatencyMarker(&test.device->ID3DLowLatencyDevice_iface,
+            1, VK_LATENCY_MARKER_PRESENT_START_NV);
+    result = hr == E_NOTIMPL && !test.calls;
+
+    test.device->vk_info.NV_low_latency2 = true;
+    test.device->vk_procs.vkSetLatencyMarkerNV = NULL;
+    hr = ID3DLowLatencyDevice_SetLatencyMarker(&test.device->ID3DLowLatencyDevice_iface,
+            2, VK_LATENCY_MARKER_PRESENT_START_NV);
+    if (hr != S_OK || test.calls)
+        result = false;
+
+    test.device->vk_procs.vkSetLatencyMarkerNV = marker_test_set_latency_marker;
+    dxgi_vk_swap_chain_test_marker_set_callback(marker_test_pause, &test);
+    marker_callback_set = true;
+    if (pthread_create(&thread, NULL, marker_test_thread, &test))
+    {
+        result = false;
+        goto cleanup;
+    }
+    thread_created = true;
+
+    pthread_mutex_lock(&test.mutex);
+    while (!test.acquired)
+        pthread_cond_wait(&test.cond, &test.mutex);
+    pthread_mutex_unlock(&test.mutex);
+
+cleanup:
+    if (test.chain)
+    {
+        if (IDXGIVkSwapChain_Release(test.chain))
+            result = false;
+    }
+    if (queue_iface)
+    {
+        if (ID3D12CommandQueue_Release(queue_iface) != (thread_created ? 1 : 0))
+            result = false;
+        queue_iface = NULL;
+    }
+    if (thread_created)
+    {
+        pthread_mutex_lock(&test.mutex);
+        test.resume = true;
+        pthread_cond_broadcast(&test.cond);
+        pthread_mutex_unlock(&test.mutex);
+        if (pthread_join(thread, NULL))
+            result = false;
+        if (test.calls != 1 || test.frame_id != UINT64_C(0x123456789abcdef0)
+                || test.marker != VK_LATENCY_MARKER_RENDERSUBMIT_START_NV)
+            result = false;
+    }
+    test.chain = NULL;
+    if (marker_callback_set)
+        dxgi_vk_swap_chain_test_marker_set_callback(NULL, NULL);
+    if (marker_test_registered)
+    {
+        test.device->vk_procs.vkSetLatencyMarkerNV = saved_marker;
+        marker_test = NULL;
+    }
+    if (cond_initialized && pthread_cond_destroy(&test.cond))
+        result = false;
+    if (mutex_initialized && pthread_mutex_destroy(&test.mutex))
+        result = false;
+    if (device && ID3D12Device_Release(device))
+        result = false;
+#ifdef _WIN32
+    if (vulkan_module && !FreeLibrary(vulkan_module))
+        result = false;
+#endif
+    return result;
+}
+
+int main(void)
+{
+    return marker_forwarding_test() ? 0 : 1;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,5 @@
 
-vkd3d_test_flags = []
+vkd3d_test_flags = ['-DVKD3D_ENABLE_TEST_HOOKS']
 vkd3d_test_deps = [ lib_d3d12, vkd3d_common_dep ]
 if vkd3d_platform == 'windows'
   vkd3d_test_deps += [ lib_dxgi ]
@@ -66,3 +66,12 @@ executable('pso-library-bloat', 'pso_library_bloat.c',
   install             : false,
   c_args              : vkd3d_test_flags,
   link_with           : [ d3d12_test_utils_lib ])
+
+marker_forwarding_test = executable('marker-forwarding',
+  'marker_forwarding.c',
+  dependencies        : [ vkd3d_dep, vkd3d_common_dep ],
+  include_directories : [ vkd3d_private_includes, include_directories('..'), include_directories('../libs/vkd3d') ],
+  install             : false,
+  c_args              : vkd3d_test_flags)
+
+test('marker-forwarding', marker_forwarding_test)


### PR DESCRIPTION
Application Reflex markers are currently handled by the custom pacer but are not forwarded through `vkSetLatencyMarkerNV`.

This restores native marker forwarding when `VK_NV_low_latency2`, a selected native swapchain, and the native proc are available. The original 64-bit frame ID and marker type are preserved. Forwarding remains independent of custom pacing activation and native Reflex sleep mode; this does not enable native sleeping or alter custom accounting behavior.

Swapchain and queue references are retained across the unlocked native call so concurrent destruction remains safe. Deterministic regression coverage verifies unavailable paths, exactly-once forwarding, frame-ID/type preservation, and concurrent lifetime behavior. Full x64/x86 builds and focused Wine regressions pass.
